### PR TITLE
Initial Update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==3.1
 django-cors-middleware==1.5.0
 django-extensions==3.0.5
-djangorestframework==3.4.4
+djangorestframework==3.11.1
 PyJWT==1.4.2
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==3.1
 django-cors-middleware==1.5.0
-django-extensions==1.7.1
+django-extensions==3.0.5
 djangorestframework==3.4.4
 PyJWT==1.4.2
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.1
-django-cors-middleware==1.3.1
+django-cors-middleware==1.5.0
 django-extensions==1.7.1
 djangorestframework==3.4.4
 PyJWT==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Django==3.1
 django-cors-middleware==1.5.0
 django-extensions==3.0.5
 djangorestframework==3.11.1
-PyJWT==1.4.2
+PyJWT==1.7.1
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ django-cors-middleware==1.5.0
 django-extensions==3.0.5
 djangorestframework==3.11.1
 PyJWT==1.7.1
-six==1.10.0
+six==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.10.5
+Django==3.1
 django-cors-middleware==1.3.1
 django-extensions==1.7.1
 djangorestframework==3.4.4


### PR DESCRIPTION


This PR sets up pyup.io on this repo and updates all dependencies at once, in a single branch.

Subsequent pull requests will update one dependency at a time, each in their own branch. If you want to start with that right away, simply close this PR.





### Update [Django](https://pypi.org/project/Django) from **1.10.5** to **3.1**.


<details>
  <summary>Changelog</summary>
  
  
   ### 3.1
   ```
   ========================

*August 4, 2020*

Welcome to Django 3.1!

These release notes cover the :ref:`new features &lt;whats-new-3.1&gt;`, as well as
some :ref:`backwards incompatible changes &lt;backwards-incompatible-3.1&gt;` you&#39;ll
want to be aware of when upgrading from Django 3.0 or earlier. We&#39;ve
:ref:`dropped some features&lt;removed-features-3.1&gt;` that have reached the end of
their deprecation cycle, and we&#39;ve :ref:`begun the deprecation process for
some features &lt;deprecated-features-3.1&gt;`.

See the :doc:`/howto/upgrade-version` guide if you&#39;re updating an existing
project.

Python compatibility
====================

Django 3.1 supports Python 3.6, 3.7, and 3.8. We **highly recommend** and only
officially support the latest release of each series.

.. _whats-new-3.1:

What&#39;s new in Django 3.1
========================

Asynchronous views and middleware support
-----------------------------------------

Django now supports a fully asynchronous request path, including:

* :ref:`Asynchronous views &lt;async-views&gt;`
* :ref:`Asynchronous middleware &lt;async-middleware&gt;`
* :ref:`Asynchronous tests and test client &lt;async-tests&gt;`

To get started with async views, you need to declare a view using
``async def``::

    async def my_view(request):
        await asyncio.sleep(0.5)
        return HttpResponse(&#39;Hello, async world!&#39;)

All asynchronous features are supported whether you are running under WSGI or
ASGI mode. However, there will be performance penalties using async code in
WSGI mode. You can read more about the specifics in :doc:`/topics/async`
documentation.

You are free to mix async and sync views, middleware, and tests as much as you
want. Django will ensure that you always end up with the right execution
context. We expect most projects will keep the majority of their views
synchronous, and only have a select few running in async mode - but it is
entirely your choice.

Django&#39;s ORM, cache layer, and other pieces of code that do long-running
network calls do not yet support async access. We expect to add support for
them in upcoming releases. Async views are ideal, however, if you are doing a
lot of API or HTTP calls inside your view, you can now natively do all those
HTTP calls in parallel to considerably speed up your view&#39;s execution.

Asynchronous support should be entirely backwards-compatible and we have tried
to ensure that it has no speed regressions for your existing, synchronous code.
It should have no noticeable effect on any existing Django projects.

JSONField for all supported database backends
---------------------------------------------

Django now includes :class:`.models.JSONField` and
:class:`forms.JSONField &lt;django.forms.JSONField&gt;` that can be used on all
supported database backends. Both fields support the use of custom JSON
encoders and decoders. The model field supports the introspection,
:ref:`lookups, and transforms &lt;querying-jsonfield&gt;` that were previously
PostgreSQL-only::

    from django.db import models

    class ContactInfo(models.Model):
        data = models.JSONField()

    ContactInfo.objects.create(data={
        &#39;name&#39;: &#39;John&#39;,
        &#39;cities&#39;: [&#39;London&#39;, &#39;Cambridge&#39;],
        &#39;pets&#39;: {&#39;dogs&#39;: [&#39;Rufus&#39;, &#39;Meg&#39;]},
    })
    ContactInfo.objects.filter(
        data__name=&#39;John&#39;,
        data__pets__has_key=&#39;dogs&#39;,
        data__cities__contains=&#39;London&#39;,
    ).delete()

If your project uses ``django.contrib.postgres.fields.JSONField``, plus the
related form field and transforms, you should adjust to use the new fields,
and generate and apply a database migration. For now, the old fields and
transforms are left as a reference to the new ones and are :ref:`deprecated as
of this release &lt;deprecated-jsonfield&gt;`.

.. _default-hashing-algorithm-usage:

``DEFAULT_HASHING_ALGORITHM`` settings
--------------------------------------

The new :setting:`DEFAULT_HASHING_ALGORITHM` transitional setting allows
specifying the default hashing algorithm to use for encoding cookies, password
reset tokens in the admin site, user sessions, and signatures created by
:class:`django.core.signing.Signer` and :meth:`django.core.signing.dumps`.

Support for SHA-256 was added in Django 3.1. If you are upgrading multiple
instances of the same project to Django 3.1, you should set
:setting:`DEFAULT_HASHING_ALGORITHM` to ``&#39;sha1&#39;`` during the transition, in
order to allow compatibility with the older versions of Django. Note that this
requires Django 3.1.1+. Once the transition to 3.1 is complete you can stop
overriding :setting:`DEFAULT_HASHING_ALGORITHM`.

This setting is deprecated as of this release, because support for tokens,
cookies, sessions, and signatures that use SHA-1 algorithm will be removed in
Django 4.0.

Minor features
--------------

:mod:`django.contrib.admin`
~~~~~~~~~~~~~~~~~~~~~~~~~~~

* The new ``django.contrib.admin.EmptyFieldListFilter`` for
  :attr:`.ModelAdmin.list_filter` allows filtering on empty values (empty
  strings and nulls) in the admin changelist view.

* Filters in the right sidebar of the admin changelist view now contain a link
  to clear all filters.

* The admin now has a sidebar on larger screens for easier navigation. It is
  enabled by default but can be disabled by using a custom ``AdminSite`` and
  setting :attr:`.AdminSite.enable_nav_sidebar` to ``False``.

  Rendering the sidebar requires access to the current request in order to set
  CSS and ARIA role affordances. This requires using
  ``&#39;django.template.context_processors.request&#39;`` in the
  ``&#39;context_processors&#39;`` option of :setting:`OPTIONS &lt;TEMPLATES-OPTIONS&gt;`.

* ``XRegExp`` is upgraded from version 2.0.0 to 3.2.0.

* jQuery is upgraded from version 3.4.1 to 3.5.1.

* Select2 library is upgraded from version 4.0.7 to 4.0.13.

:mod:`django.contrib.auth`
~~~~~~~~~~~~~~~~~~~~~~~~~~

* The default iteration count for the PBKDF2 password hasher is increased from
  180,000 to 216,000.

* The new :setting:`PASSWORD_RESET_TIMEOUT` setting allows defining the number
  of seconds a password reset link is valid for. This is encouraged instead of
  the deprecated ``PASSWORD_RESET_TIMEOUT_DAYS`` setting, which will be removed
  in Django 4.0.

* The password reset mechanism now uses the SHA-256 hashing algorithm. Support
  for tokens that use the old hashing algorithm remains until Django 4.0.

* :meth:`.AbstractBaseUser.get_session_auth_hash` now uses the SHA-256 hashing
  algorithm. Support for user sessions that use the old hashing algorithm
  remains until Django 4.0.

:mod:`django.contrib.contenttypes`
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

* The new :option:`remove_stale_contenttypes --include-stale-apps` option
  allows removing stale content types from previously installed apps that have
  been removed from :setting:`INSTALLED_APPS`.

:mod:`django.contrib.gis`
~~~~~~~~~~~~~~~~~~~~~~~~~

* :lookup:`relate` lookup is now supported on MariaDB.

* Added the :attr:`.LinearRing.is_counterclockwise` property.

* :class:`~django.contrib.gis.db.models.functions.AsGeoJSON` is now supported
  on Oracle.

* Added the :class:`~django.contrib.gis.db.models.functions.AsWKB` and
  :class:`~django.contrib.gis.db.models.functions.AsWKT` functions.

* Added support for PostGIS 3 and GDAL 3.

:mod:`django.contrib.humanize`
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

* :tfilter:`intword` template filter now supports negative integers.

:mod:`django.contrib.postgres`
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

* The new :class:`~django.contrib.postgres.indexes.BloomIndex` class allows
  creating ``bloom`` indexes in the database. The new
  :class:`~django.contrib.postgres.operations.BloomExtension` migration
  operation installs the ``bloom`` extension to add support for this index.

* :meth:`~django.db.models.Model.get_FOO_display` now supports
  :class:`~django.contrib.postgres.fields.ArrayField` and
  :class:`~django.contrib.postgres.fields.RangeField`.

* The new :lookup:`rangefield.lower_inc`, :lookup:`rangefield.lower_inf`,
  :lookup:`rangefield.upper_inc`, and :lookup:`rangefield.upper_inf` lookups
  allow querying :class:`~django.contrib.postgres.fields.RangeField` by a bound
  type.

* :lookup:`rangefield.contained_by` now supports
  :class:`~django.db.models.SmallAutoField`,
  :class:`~django.db.models.AutoField`,
  :class:`~django.db.models.BigAutoField`,
  :class:`~django.db.models.SmallIntegerField`, and
  :class:`~django.db.models.DecimalField`.

* :class:`~django.contrib.postgres.search.SearchQuery` now supports
  ``&#39;websearch&#39;`` search type on PostgreSQL 11+.

* :class:`SearchQuery.value &lt;django.contrib.postgres.search.SearchQuery&gt;` now
  supports query expressions.

* The new :class:`~django.contrib.postgres.search.SearchHeadline` class allows
  highlighting search results.

* :lookup:`search` lookup now supports query expressions.

* The new ``cover_density`` parameter of
  :class:`~django.contrib.postgres.search.SearchRank` allows ranking by cover
  density.

* The new ``normalization`` parameter of
  :class:`~django.contrib.postgres.search.SearchRank` allows rank
  normalization.

* The new :attr:`.ExclusionConstraint.deferrable` attribute allows creating
  deferrable exclusion constraints.

:mod:`django.contrib.sessions`
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

* The :setting:`SESSION_COOKIE_SAMESITE` setting now allows ``&#39;None&#39;`` (string)
  value to explicitly state that the cookie is sent with all same-site and
  cross-site requests.

:mod:`django.contrib.staticfiles`
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

* The :setting:`STATICFILES_DIRS` setting now supports :class:`pathlib.Path`.

Cache
~~~~~

* The :func:`~django.views.decorators.cache.cache_control` decorator and
  :func:`~django.utils.cache.patch_cache_control` method now support multiple
  field names in the ``no-cache`` directive for the ``Cache-Control`` header,
  according to :rfc:`7234section-5.2.2.2`.

* :meth:`~django.core.caches.cache.delete` now returns ``True`` if the key was
  successfully deleted, ``False`` otherwise.

CSRF
~~~~

* The :setting:`CSRF_COOKIE_SAMESITE` setting now allows ``&#39;None&#39;`` (string)
  value to explicitly state that the cookie is sent with all same-site and
  cross-site requests.

Email
~~~~~

* The :setting:`EMAIL_FILE_PATH` setting, used by the :ref:`file email backend
  &lt;topic-email-file-backend&gt;`, now supports :class:`pathlib.Path`.

Error Reporting
~~~~~~~~~~~~~~~

* :class:`django.views.debug.SafeExceptionReporterFilter` now filters sensitive
  values from ``request.META`` in exception reports.

* The new :attr:`.SafeExceptionReporterFilter.cleansed_substitute` and
  :attr:`.SafeExceptionReporterFilter.hidden_settings` attributes allow
  customization of sensitive settings and ``request.META`` filtering in
  exception reports.

* The technical 404 debug view now respects
  :setting:`DEFAULT_EXCEPTION_REPORTER_FILTER` when applying settings
  filtering.

* The new :setting:`DEFAULT_EXCEPTION_REPORTER` allows providing a
  :class:`django.views.debug.ExceptionReporter` subclass to customize exception
  report generation. See :ref:`custom-error-reports` for details.

File Storage
~~~~~~~~~~~~

* ``FileSystemStorage.save()`` method now supports :class:`pathlib.Path`.

* :class:`~django.db.models.FileField` and
  :class:`~django.db.models.ImageField` now accept a callable for ``storage``.
  This allows you to modify the used storage at runtime, selecting different
  storages for different environments, for example.

Forms
~~~~~

* :class:`~django.forms.ModelChoiceIterator`, used by
  :class:`~django.forms.ModelChoiceField` and
  :class:`~django.forms.ModelMultipleChoiceField`, now uses
  :class:`~django.forms.ModelChoiceIteratorValue` that can be used by widgets
  to access model instances. See :ref:`iterating-relationship-choices` for
  details.

* :class:`django.forms.DateTimeField` now accepts dates in a subset of ISO 8601
  datetime formats, including optional timezone, e.g. ``2019-10-10T06:47``,
  ``2019-10-10T06:47:23+04:00``, or ``2019-10-10T06:47:23Z``. The timezone will
  always be retained if provided, with timezone-aware datetimes being returned
  even when :setting:`USE_TZ` is ``False``.

  Additionally, ``DateTimeField`` now uses ``DATE_INPUT_FORMATS`` in addition
  to ``DATETIME_INPUT_FORMATS`` when converting a field input to a ``datetime``
  value.

* :attr:`.MultiWidget.widgets` now accepts a dictionary which allows
  customizing subwidget ``name`` attributes.

* The new :attr:`.BoundField.widget_type` property can be used to dynamically
  adjust form rendering based upon the widget type.

Internationalization
~~~~~~~~~~~~~~~~~~~~

* The :setting:`LANGUAGE_COOKIE_SAMESITE` setting now allows ``&#39;None&#39;``
  (string) value to explicitly state that the cookie is sent with all same-site
  and cross-site requests.

* Added support and translations for the Algerian Arabic, Igbo, Kyrgyz, Tajik,
  and Turkmen languages.

Management Commands
~~~~~~~~~~~~~~~~~~~

* The new :option:`check --database` option allows specifying database aliases
  for running the ``database`` system checks. Previously these checks were
  enabled for all configured :setting:`DATABASES` by passing the ``database``
  tag to the command.

* The new :option:`migrate --check` option makes the command exit with a
  non-zero status when unapplied migrations are detected.

* The new ``returncode`` argument for
  :attr:`~django.core.management.CommandError` allows customizing the exit
  status for management commands.

* The new :option:`dbshell -- ARGUMENTS &lt;dbshell --&gt;` option allows passing
  extra arguments to the command-line client for the database.

* The :djadmin:`flush` and :djadmin:`sqlflush` commands now include SQL to
  reset sequences on SQLite.

Models
~~~~~~

* The new :class:`~django.db.models.functions.ExtractIsoWeekDay` function
  extracts ISO-8601 week days from :class:`~django.db.models.DateField` and
  :class:`~django.db.models.DateTimeField`, and the new :lookup:`iso_week_day`
  lookup allows querying by an ISO-8601 day of week.

* :meth:`.QuerySet.explain` now supports:

  * ``TREE`` format on MySQL 8.0.16+,
  * ``analyze`` option on MySQL 8.0.18+ and MariaDB.

* Added :class:`~django.db.models.PositiveBigIntegerField` which acts much like
  a :class:`~django.db.models.PositiveIntegerField` except that it only allows
  values under a certain (database-dependent) limit. Values from ``0`` to
  ``9223372036854775807`` are safe in all databases supported by Django.

* The new :class:`~django.db.models.RESTRICT` option for
  :attr:`~django.db.models.ForeignKey.on_delete` argument of ``ForeignKey`` and
  ``OneToOneField`` emulates the behavior of the SQL constraint ``ON DELETE
  RESTRICT``.

* :attr:`.CheckConstraint.check` now supports boolean expressions.

* The :meth:`.RelatedManager.add`, :meth:`~.RelatedManager.create`, and
  :meth:`~.RelatedManager.set` methods now accept callables as values in the
  ``through_defaults`` argument.

* The new ``is_dst``  parameter of the :meth:`.QuerySet.datetimes` determines
  the treatment of nonexistent and ambiguous datetimes.

* The new :class:`~django.db.models.F` expression ``bitxor()`` method allows
  :ref:`bitwise XOR operation &lt;using-f-expressions-in-filters&gt;`.

* :meth:`.QuerySet.bulk_create` now sets the primary key on objects when using
  MariaDB 10.5+.

* The ``DatabaseOperations.sql_flush()`` method now generates more efficient
  SQL on MySQL by using ``DELETE`` instead of ``TRUNCATE`` statements for
  tables which don&#39;t require resetting sequences.

* SQLite functions are now marked as :py:meth:`deterministic
  &lt;sqlite3.Connection.create_function&gt;` on Python 3.8+. This allows using them
  in check constraints and partial indexes.

* The new :attr:`.UniqueConstraint.deferrable` attribute allows creating
  deferrable unique constraints.

Pagination
~~~~~~~~~~

* :class:`~django.core.paginator.Paginator` can now be iterated over to yield
  its pages.

Requests and Responses
~~~~~~~~~~~~~~~~~~~~~~

* If :setting:`ALLOWED_HOSTS` is empty and ``DEBUG=True``, subdomains of
  localhost are now allowed in the ``Host`` header, e.g. ``static.localhost``.

* :meth:`.HttpResponse.set_cookie` and :meth:`.HttpResponse.set_signed_cookie`
  now allow using ``samesite=&#39;None&#39;`` (string) to explicitly state that the
  cookie is sent with all same-site and cross-site requests.

* The new :meth:`.HttpRequest.accepts` method returns whether the request
  accepts the given MIME type according to the ``Accept`` HTTP header.

.. _whats-new-security-3.1:

Security
~~~~~~~~

* The :setting:`SECURE_REFERRER_POLICY` setting now defaults to
  ``&#39;same-origin&#39;``. With this configured,
  :class:`~django.middleware.security.SecurityMiddleware` sets the
  :ref:`referrer-policy` header to ``same-origin`` on all responses that do not
  already have it. This prevents the ``Referer`` header being sent to other
  origins. If you need the previous behavior, explicitly set
  :setting:`SECURE_REFERRER_POLICY` to ``None``.

* The default algorithm of :class:`django.core.signing.Signer`,
  :meth:`django.core.signing.loads`, and :meth:`django.core.signing.dumps` is
  changed to the SHA-256. Support for signatures made with the old SHA-1
  algorithm remains until Django 4.0.

  Also, the new ``algorithm`` parameter of the
  :class:`~django.core.signing.Signer` allows customizing the hashing
  algorithm.

Templates
~~~~~~~~~

* The renamed :ttag:`translate` and :ttag:`blocktranslate` template tags are
  introduced for internationalization in template code. The older :ttag:`trans`
  and :ttag:`blocktrans` template tags aliases continue to work, and will be
  retained for the foreseeable future.

* The :ttag:`include` template tag now accepts iterables of template names.

Tests
~~~~~

* :class:`~django.test.SimpleTestCase` now implements the ``debug()`` method to
  allow running a test without collecting the result and catching exceptions.
  This can be used to support running tests under a debugger.

* The new :setting:`MIGRATE &lt;TEST_MIGRATE&gt;` test database setting allows
  disabling of migrations during a test database creation.

* Django test runner now supports a :option:`test --buffer` option to discard
  output for passing tests.

* :class:`~django.test.runner.DiscoverRunner` now skips running the system
  checks on databases not :ref:`referenced by tests&lt;testing-multi-db&gt;`.

* :class:`~django.test.TransactionTestCase` teardown is now faster on MySQL
  due to :djadmin:`flush` command improvements. As a side effect the latter
  doesn&#39;t automatically reset sequences on teardown anymore. Enable
  :attr:`.TransactionTestCase.reset_sequences` if your tests require this
  feature.

URLs
~~~~

* :ref:`Path converters &lt;registering-custom-path-converters&gt;` can now raise
  ``ValueError`` in ``to_url()`` to indicate no match when reversing URLs.

Utilities
~~~~~~~~~

* :func:`~django.utils.encoding.filepath_to_uri` now supports
  :class:`pathlib.Path`.

* :func:`~django.utils.dateparse.parse_duration` now supports comma separators
  for decimal fractions in the ISO 8601 format.

* :func:`~django.utils.dateparse.parse_datetime`,
  :func:`~django.utils.dateparse.parse_duration`, and
  :func:`~django.utils.dateparse.parse_time` now support comma separators for
  milliseconds.

Miscellaneous
~~~~~~~~~~~~~

* The SQLite backend now supports :class:`pathlib.Path` for the ``NAME``
  setting.

* The ``settings.py`` generated by the :djadmin:`startproject` command now uses
  :class:`pathlib.Path` instead of :mod:`os.path` for building filesystem
  paths.

* The :setting:`TIME_ZONE &lt;DATABASE-TIME_ZONE&gt;` setting is now allowed on
  databases that support time zones.

.. _backwards-incompatible-3.1:

Backwards incompatible changes in 3.1
=====================================

Database backend API
--------------------

This section describes changes that may be needed in third-party database
backends.

* ``DatabaseOperations.fetch_returned_insert_columns()`` now requires an
  additional ``returning_params`` argument.

* ``connection.timezone`` property is now ``&#39;UTC&#39;`` by default, or the
  :setting:`TIME_ZONE &lt;DATABASE-TIME_ZONE&gt;` when :setting:`USE_TZ` is ``True``
  on databases that support time zones. Previously, it was ``None`` on
  databases that support time zones.

* ``connection._nodb_connection`` property is changed to the
  ``connection._nodb_cursor()`` method and now returns a context manager that
  yields a cursor and automatically closes the cursor and connection upon
  exiting the ``with`` statement.

* ``DatabaseClient.runshell()`` now requires an additional ``parameters``
  argument as a list of extra arguments to pass on to the command-line client.

* The ``sequences`` positional argument of ``DatabaseOperations.sql_flush()``
  is replaced by the boolean keyword-only argument ``reset_sequences``. If
  ``True``, the sequences of the truncated tables will be reset.

* The ``allow_cascade`` argument of ``DatabaseOperations.sql_flush()`` is now a
  keyword-only argument.

* The ``using`` positional argument of
  ``DatabaseOperations.execute_sql_flush()`` is removed. The method now uses
  the database of the called instance.

* Third-party database backends must implement support for ``JSONField`` or set
  ``DatabaseFeatures.supports_json_field`` to ``False``. If storing primitives
  is not supported, set ``DatabaseFeatures.supports_primitives_in_json_field``
  to ``False``. If there is a true datatype for JSON, set
  ``DatabaseFeatures.has_native_json_field`` to ``True``. If
  :lookup:`jsonfield.contains` and :lookup:`jsonfield.contained_by` are not
  supported, set ``DatabaseFeatures.supports_json_field_contains`` to
  ``False``.

* Third party database backends must implement introspection for ``JSONField``
  or set ``can_introspect_json_field`` to ``False``.

Dropped support for MariaDB 10.1
--------------------------------

Upstream support for MariaDB 10.1 ends in October 2020. Django 3.1 supports
MariaDB 10.2 and higher.

``contrib.admin`` browser support
---------------------------------

The admin no longer supports the legacy Internet Explorer browser. See
:ref:`the admin FAQ &lt;admin-browser-support&gt;` for details on supported browsers.

:attr:`AbstractUser.first_name &lt;django.contrib.auth.models.User.first_name&gt;` ``max_length`` increased to 150
------------------------------------------------------------------------------------------------------------

A migration for :attr:`django.contrib.auth.models.User.first_name` is included.
If you have a custom user model inheriting from ``AbstractUser``, you&#39;ll need
to generate and apply a database migration for your user model.

If you want to preserve the 30 character limit for first names, use a custom
form::

    from django import forms
    from django.contrib.auth.forms import UserChangeForm

    class MyUserChangeForm(UserChangeForm):
        first_name = forms.CharField(max_length=30, required=False)

If you wish to keep this restriction in the admin when editing users, set
``UserAdmin.form`` to use this form::

    from django.contrib.auth.admin import UserAdmin
    from django.contrib.auth.models import User

    class MyUserAdmin(UserAdmin):
        form = MyUserChangeForm

    admin.site.unregister(User)
    admin.site.register(User, MyUserAdmin)

Miscellaneous
-------------

* The cache keys used by :ttag:`cache` and generated by
  :func:`~django.core.cache.utils.make_template_fragment_key` are different
  from the keys generated by older versions of Django. After upgrading to
  Django 3.1, the first request to any previously cached template fragment will
  be a cache miss.

* The logic behind the decision to return a redirection fallback or a 204 HTTP
  response from the :func:`~django.views.i18n.set_language` view is now based
  on the ``Accept`` HTTP header instead of the ``X-Requested-With`` HTTP header
  presence.

* The compatibility imports of ``django.core.exceptions.EmptyResultSet`` in
  ``django.db.models.query``, ``django.db.models.sql``, and
  ``django.db.models.sql.datastructures`` are removed.

* The compatibility import of ``django.core.exceptions.FieldDoesNotExist`` in
  ``django.db.models.fields`` is removed.

* The compatibility imports of ``django.forms.utils.pretty_name()`` and
  ``django.forms.boundfield.BoundField`` in ``django.forms.forms`` are removed.

* The compatibility imports of ``Context``, ``ContextPopException``, and
  ``RequestContext`` in ``django.template.base`` are removed.

* The compatibility import of
  ``django.contrib.admin.helpers.ACTION_CHECKBOX_NAME`` in
  ``django.contrib.admin`` is removed.

* The :setting:`STATIC_URL` and :setting:`MEDIA_URL` settings set to relative
  paths are now prefixed by the server-provided value of ``SCRIPT_NAME`` (or
  ``/`` if not set). This change should not affect settings set to valid URLs
  or absolute paths.

* :class:`~django.middleware.http.ConditionalGetMiddleware` no longer adds the
  ``ETag`` header to responses with an empty
  :attr:`~django.http.HttpResponse.content`.

* ``django.utils.decorators.classproperty()`` decorator is made public and
  moved to :class:`django.utils.functional.classproperty()`.

* :tfilter:`floatformat` template filter now outputs (positive) ``0`` for
  negative numbers which round to zero.

* :attr:`Meta.ordering &lt;django.db.models.Options.ordering&gt;` and
  :attr:`Meta.unique_together &lt;django.db.models.Options.unique_together&gt;`
  options on models in ``django.contrib`` modules that were formerly tuples are
  now lists.

* The admin calendar widget now handles two-digit years according to the Open
  Group Specification, i.e. values between 69 and 99 are mapped to the previous
  century, and values between 0 and 68 are mapped to the current century.

* Date-only formats are removed from the default list for
  :setting:`DATETIME_INPUT_FORMATS`.

* The :class:`~django.forms.FileInput` widget no longer renders with the
  ``required`` HTML attribute when initial data exists.

* The undocumented ``django.views.debug.ExceptionReporterFilter`` class is
  removed. As per the :ref:`custom-error-reports` documentation, classes to be
  used with :setting:`DEFAULT_EXCEPTION_REPORTER_FILTER` need to inherit from
  :class:`django.views.debug.SafeExceptionReporterFilter`.

* The cache timeout set by :func:`~django.views.decorators.cache.cache_page`
  decorator now takes precedence over the ``max-age`` directive from the
  ``Cache-Control`` header.

* Providing a non-local remote field in the :attr:`.ForeignKey.to_field`
  argument now raises :class:`~django.core.exceptions.FieldError`.

* :setting:`SECURE_REFERRER_POLICY` now defaults to ``&#39;same-origin&#39;``. See the
  *What&#39;s New* :ref:`Security section &lt;whats-new-security-3.1&gt;` above for more
  details.

* :djadmin:`check` management command now runs the ``database`` system checks
  only for database aliases specified using :option:`check --database` option.

* :djadmin:`migrate` management command now runs the ``database`` system checks
  only for a database to migrate.

* The admin CSS classes ``row1`` and ``row2`` are removed in favor of
  ``:nth-child(odd)`` and ``:nth-child(even)`` pseudo-classes.

* The :func:`~django.contrib.auth.hashers.make_password` function now requires
  its argument to be a string or bytes. Other types should be explicitly cast
  to one of these.

* The undocumented ``version`` parameter to the
  :class:`~django.contrib.gis.db.models.functions.AsKML` function is removed.

* :ref:`JSON and YAML serializers &lt;serialization-formats&gt;`, used by
  :djadmin:`dumpdata`, now dump all data with Unicode by default. If you need
  the previous behavior, pass ``ensure_ascii=True`` to JSON serializer, or
  ``allow_unicode=False`` to YAML serializer.

* The auto-reloader no longer monitors changes in built-in Django translation
  files.

* The minimum supported version of ``mysqlclient`` is increased from 1.3.13 to
  1.4.0.

* The undocumented ``django.contrib.postgres.forms.InvalidJSONInput`` and
  ``django.contrib.postgres.forms.JSONString`` are moved to
  ``django.forms.fields``.

* The undocumented ``django.contrib.postgres.fields.jsonb.JsonAdapter`` class
  is removed.

* The :ttag:`{% localize off %} &lt;localize&gt;` tag and :tfilter:`unlocalize`
  filter no longer respect :setting:`DECIMAL_SEPARATOR` setting.

* The minimum supported version of ``asgiref`` is increased from 3.2 to
  3.2.10.

* The :doc:`Media &lt;/topics/forms/media&gt;` class now renders ``&lt;script&gt;`` tags
  without the ``type`` attribute to follow `WHATWG recommendations
  &lt;https://html.spec.whatwg.org/multipage/scripting.htmlthe-script-element&gt;`_.

.. _deprecated-features-3.1:

Features deprecated in 3.1
==========================

.. _deprecated-jsonfield:

PostgreSQL ``JSONField``
------------------------

``django.contrib.postgres.fields.JSONField`` and
``django.contrib.postgres.forms.JSONField`` are deprecated in favor of
:class:`.models.JSONField` and
:class:`forms.JSONField &lt;django.forms.JSONField&gt;`.

The undocumented ``django.contrib.postgres.fields.jsonb.KeyTransform`` and
``django.contrib.postgres.fields.jsonb.KeyTextTransform`` are also deprecated
in favor of the transforms in ``django.db.models.fields.json``.

The new ``JSONField``\s, ``KeyTransform``, and ``KeyTextTransform`` can be used
on all supported database backends.

Miscellaneous
-------------

* ``PASSWORD_RESET_TIMEOUT_DAYS`` setting is deprecated in favor of
  :setting:`PASSWORD_RESET_TIMEOUT`.

* The undocumented usage of the :lookup:`isnull` lookup with non-boolean values
  as the right-hand side is deprecated, use ``True`` or ``False`` instead.

* The barely documented ``django.db.models.query_utils.InvalidQuery`` exception
  class is deprecated in favor of
  :class:`~django.core.exceptions.FieldDoesNotExist` and
  :class:`~django.core.exceptions.FieldError`.

* The ``django-admin.py`` entry point is deprecated in favor of
  ``django-admin``.

* The ``HttpRequest.is_ajax()`` method is deprecated as it relied on a
  jQuery-specific way of signifying AJAX calls, while current usage tends to
  use the JavaScript `Fetch API
  &lt;https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API&gt;`_. Depending on
  your use case, you can either write your own AJAX detection method, or use
  the new :meth:`.HttpRequest.accepts` method if your code depends on the
  client ``Accept`` HTTP header.

  If you are writing your own AJAX detection method, ``request.is_ajax()`` can
  be reproduced exactly as
  ``request.headers.get(&#39;x-requested-with&#39;) == &#39;XMLHttpRequest&#39;``.

* Passing ``None`` as the first argument to
  ``django.utils.deprecation.MiddlewareMixin.__init__()`` is deprecated.

* The encoding format of cookies values used by
  :class:`~django.contrib.messages.storage.cookie.CookieStorage` is different
  from the format generated by older versions of Django. Support for the old
  format remains until Django 4.0.

* The encoding format of sessions is different from the format generated by
  older versions of Django. Support for the old format remains until Django
  4.0.

* The purely documentational ``providing_args`` argument for
  :class:`~django.dispatch.Signal` is deprecated. If you rely on this
  argument as documentation, you can move the text to a code comment or
  docstring.

* Calling ``django.utils.crypto.get_random_string()`` without a ``length``
  argument is deprecated.

* The ``list`` message for :class:`~django.forms.ModelMultipleChoiceField` is
  deprecated in favor of ``invalid_list``.

* Passing raw column aliases to :meth:`.QuerySet.order_by` is deprecated. The
  same result can be achieved by passing aliases in a
  :class:`~django.db.models.expressions.RawSQL` instead beforehand.

* The ``NullBooleanField`` model field is deprecated in favor of
  ``BooleanField(null=True)``.

* ``django.conf.urls.url()`` alias of :func:`django.urls.re_path` is
  deprecated.

* The ``{% ifequal %}`` and ``{% ifnotequal %}`` template tags are deprecated
  in favor of :ttag:`{% if %}&lt;if&gt;`. ``{% if %}`` covers all use cases, but if
  you need to continue using these tags, they can be extracted from Django to a
  module and included as a built-in tag in the :class:`&#39;builtins&#39;
  &lt;django.template.backends.django.DjangoTemplates&gt;` option in
  :setting:`OPTIONS &lt;TEMPLATES-OPTIONS&gt;`.

* ``DEFAULT_HASHING_ALGORITHM`` transitional setting is deprecated.

.. _removed-features-3.1:

Features removed in 3.1
=======================

These features have reached the end of their deprecation cycle and are removed
in Django 3.1.

See :ref:`deprecated-features-2.2` for details on these changes, including how
to remove usage of these features.

* ``django.utils.timezone.FixedOffset`` is removed.

* ``django.core.paginator.QuerySetPaginator`` is removed.

* A model&#39;s ``Meta.ordering`` doesn&#39;t affect ``GROUP BY`` queries.

* ``django.contrib.postgres.fields.FloatRangeField`` and
  ``django.contrib.postgres.forms.FloatRangeField`` are removed.

* The ``FILE_CHARSET`` setting is removed.

* ``django.contrib.staticfiles.storage.CachedStaticFilesStorage`` is removed.

* The ``RemoteUserBackend.configure_user()`` method requires ``request`` as the
  first positional argument.

* Support for ``SimpleTestCase.allow_database_queries`` and
  ``TransactionTestCase.multi_db`` is removed.


==========================
   ```
   
  
  
   ### 3.0.9
   ```
   ==========================

*August 3, 2020*

Django 3.0.9 fixes several bugs in 3.0.8.

Bugfixes
========

* Allowed setting the ``SameSite`` cookie flag in
  :meth:`.HttpResponse.delete_cookie` (:ticket:`31790`).

* Fixed crash when sending emails to addresses with display names longer than
  75 chars on Python 3.6.11+, 3.7.8+, and 3.8.4+ (:ticket:`31784`).


==========================
   ```
   
  
  
   ### 3.0.8
   ```
   ==========================

*July 1, 2020*

Django 3.0.8 fixes several bugs in 3.0.7.

Bugfixes
========

* Fixed messages of ``InvalidCacheKey`` exceptions and ``CacheKeyWarning``
  warnings raised by cache key validation (:ticket:`31654`).

* Fixed a regression in Django 3.0.7 that caused a queryset crash when grouping
  by a many-to-one relationship (:ticket:`31660`).

* Reallowed, following a regression in Django 3.0, non-expressions having a
  ``filterable`` attribute to be used as the right-hand side in queryset
  filters (:ticket:`31664`).

* Fixed a regression in Django 3.0.2 that caused a migration crash on
  PostgreSQL when adding a foreign key to a model with a namespaced
  ``db_table`` (:ticket:`31735`).

* Added compatibility for ``cx_Oracle`` 8 (:ticket:`31751`).


==========================
   ```
   
  
  
   ### 3.0.7
   ```
   ==========================

*June 3, 2020*

Django 3.0.7 fixes two security issues and several bugs in 3.0.6.

CVE-2020-13254: Potential data leakage via malformed memcached keys
===================================================================

In cases where a memcached backend does not perform key validation, passing
malformed cache keys could result in a key collision, and potential data
leakage. In order to avoid this vulnerability, key validation is added to the
memcached cache backends.

CVE-2020-13596: Possible XSS via admin ``ForeignKeyRawIdWidget``
================================================================

Query parameters for the admin ``ForeignKeyRawIdWidget`` were not properly URL
encoded, posing an XSS attack vector. ``ForeignKeyRawIdWidget`` now
ensures query parameters are correctly URL encoded.

Bugfixes
========

* Fixed a regression in Django 3.0 by restoring the ability to use field
  lookups in ``Meta.ordering`` (:ticket:`31538`).

* Fixed a regression in Django 3.0 where ``QuerySet.values()`` and
  ``values_list()`` crashed if a queryset contained an aggregation and a
  subquery annotation (:ticket:`31566`).

* Fixed a regression in Django 3.0 where aggregates used wrong annotations when
  a queryset has multiple subqueries annotations (:ticket:`31568`).

* Fixed a regression in Django 3.0 where ``QuerySet.values()`` and
  ``values_list()`` crashed if a queryset contained an aggregation and an
  ``Exists()`` annotation on Oracle (:ticket:`31584`).

* Fixed a regression in Django 3.0 where all resolved ``Subquery()``
  expressions were considered equal (:ticket:`31607`).

* Fixed a regression in Django 3.0.5 that affected translation loading for apps
  providing translations for territorial language variants as well as a generic
  language, where the project has different plural equations for the language
  (:ticket:`31570`).

* Tracking a jQuery security release, upgraded the version of jQuery used by
  the admin from 3.4.1 to 3.5.1.


==========================
   ```
   
  
  
   ### 3.0.6
   ```
   ==========================

*May 4, 2020*

Django 3.0.6 fixes a bug in 3.0.5.

Bugfixes
========

* Fixed a regression in Django 3.0 that caused a crash when filtering a
  ``Subquery()`` annotation of a queryset containing a single related field
  against a ``SimpleLazyObject`` (:ticket:`31420`).


==========================
   ```
   
  
  
   ### 3.0.5
   ```
   ==========================

*April 1, 2020*

Django 3.0.5 fixes several bugs in 3.0.4.

Bugfixes
========

* Added the ability to handle ``.po`` files containing different plural
  equations for the same language (:ticket:`30439`).

* Fixed a regression in Django 3.0 where ``QuerySet.values()`` and
  ``values_list()`` crashed if a queryset contained an aggregation and
  ``Subquery()`` annotation that collides with a field name (:ticket:`31377`).


==========================
   ```
   
  
  
   ### 3.0.4
   ```
   ==========================

*March 4, 2020*

Django 3.0.4 fixes a security issue and several bugs in 3.0.3.

CVE-2020-9402: Potential SQL injection via ``tolerance`` parameter in GIS functions and aggregates on Oracle
============================================================================================================

GIS functions and aggregates on Oracle were subject to SQL injection,
using a suitably crafted ``tolerance``.

Bugfixes
========

* Fixed a data loss possibility when using caching from async code
  (:ticket:`31253`).

* Fixed a regression in Django 3.0 that caused a file response using a
  temporary file to be closed incorrectly (:ticket:`31240`).

* Fixed a data loss possibility in the
  :meth:`~django.db.models.query.QuerySet.select_for_update`. When using
  related fields or parent link fields with :ref:`multi-table-inheritance` in
  the ``of`` argument, the corresponding models were not locked
  (:ticket:`31246`).

* Fixed a regression in Django 3.0 that caused misplacing parameters in logged
  SQL queries on Oracle (:ticket:`31271`).

* Fixed a regression in Django 3.0.3 that caused misplacing parameters of SQL
  queries when subtracting ``DateField`` or ``DateTimeField`` expressions on
  MySQL (:ticket:`31312`).

* Fixed a regression in Django 3.0 that didn&#39;t include subqueries spanning
  multivalued relations in the ``GROUP BY`` clause (:ticket:`31150`).


==========================
   ```
   
  
  
   ### 3.0.3
   ```
   ==========================

*February 3, 2020*

Django 3.0.3 fixes a security issue and several bugs in 3.0.2.

CVE-2020-7471: Potential SQL injection via ``StringAgg(delimiter)``
===================================================================

:class:`~django.contrib.postgres.aggregates.StringAgg` aggregation function was
subject to SQL injection, using a suitably crafted ``delimiter``.

Bugfixes
========

* Fixed a regression in Django 3.0 that caused a crash when subtracting
  ``DateField``, ``DateTimeField``, or ``TimeField`` from a ``Subquery()``
  annotation (:ticket:`31133`).

* Fixed a regression in Django 3.0 where ``QuerySet.values()`` and
  ``values_list()`` crashed if a queryset contained an aggregation and
  ``Exists()`` annotation (:ticket:`31136`).

* Relaxed the system check added in Django 3.0 to reallow use of a sublanguage
  in the :setting:`LANGUAGE_CODE` setting, when a base language is available in
  Django but the sublanguage is not (:ticket:`31141`).

* Added support for using enumeration types ``TextChoices``,
  ``IntegerChoices``, and ``Choices`` in templates (:ticket:`31154`).

* Fixed a system check to ensure the ``max_length`` attribute fits the longest
  choice, when a named group contains only non-string values (:ticket:`31155`).

* Fixed a regression in Django 2.2 that caused a crash of
  :class:`~django.contrib.postgres.aggregates.ArrayAgg` and
  :class:`~django.contrib.postgres.aggregates.StringAgg` with ``filter``
  argument when used in a ``Subquery`` (:ticket:`31097`).

* Fixed a regression in Django 2.2.7 that caused
  :meth:`~django.db.models.Model.get_FOO_display` to work incorrectly when
  overriding inherited choices (:ticket:`31124`).

* Fixed a regression in Django 3.0 that caused a crash of
  ``QuerySet.prefetch_related()`` for ``GenericForeignKey`` with a custom
  ``ContentType`` foreign key (:ticket:`31190`).


==========================
   ```
   
  
  
   ### 3.0.2
   ```
   ==========================

*January 2, 2020*

Django 3.0.2 fixes several bugs in 3.0.1.

Bugfixes
========

* Fixed a regression in Django 3.0 that didn&#39;t include columns referenced by a
  ``Subquery()`` in the ``GROUP BY`` clause (:ticket:`31094`).

* Fixed a regression in Django 3.0 where ``QuerySet.exists()`` crashed if a
  queryset contained an aggregation over a ``Subquery()`` (:ticket:`31109`).

* Fixed a regression in Django 3.0 that caused a migration crash on PostgreSQL
  10+ when adding a foreign key and changing data in the same migration
  (:ticket:`31106`).

* Fixed a regression in Django 3.0 where loading fixtures crashed for models
  defining a :attr:`~django.db.models.Field.default` for the primary key
  (:ticket:`31071`).


==========================
   ```
   
  
  
   ### 3.0.1
   ```
   ==========================

*December 18, 2019*

Django 3.0.1 fixes a security issue and several bugs in 3.0.

CVE-2019-19844: Potential account hijack via password reset form
================================================================

By submitting a suitably crafted email address making use of Unicode
characters, that compared equal to an existing user email when lower-cased for
comparison, an attacker could be sent a password reset token for the matched
account.

In order to avoid this vulnerability, password reset requests now compare the
submitted email using the stricter, recommended algorithm for case-insensitive
comparison of two identifiers from `Unicode Technical Report 36, section
2.11.2(B)(2)`__. Upon a match, the email containing the reset token will be
sent to the email address on record rather than the submitted address.

.. __: https://www.unicode.org/reports/tr36/Recommendations_General

Bugfixes
========

* Fixed a regression in Django 3.0 by restoring the ability to use Django
  inside Jupyter and other environments that force an async context, by adding
  an option to disable :ref:`async-safety` mechanism with
  :envvar:`DJANGO_ALLOW_ASYNC_UNSAFE` environment variable (:ticket:`31056`).

* Fixed a regression in Django 3.0 where ``RegexPattern``, used by
  :func:`~django.urls.re_path`, returned positional arguments to be passed to
  the view when all optional named groups were missing (:ticket:`31061`).

* Reallowed, following a regression in Django 3.0,
  :class:`~django.db.models.expressions.Window` expressions to be used in
  conditions outside of queryset filters, e.g. in
  :class:`~django.db.models.expressions.When` conditions (:ticket:`31060`).

* Fixed a data loss possibility in
  :class:`~django.contrib.postgres.forms.SplitArrayField`. When using with
  ``ArrayField(BooleanField())``, all values after the first ``True`` value
  were marked as checked instead of preserving passed values (:ticket:`31073`).


========================
   ```
   
  
  
   ### 3.0
   ```
   ========================

*December 2, 2019*

Welcome to Django 3.0!

These release notes cover the :ref:`new features &lt;whats-new-3.0&gt;`, as well as
some :ref:`backwards incompatible changes &lt;backwards-incompatible-3.0&gt;` you&#39;ll
want to be aware of when upgrading from Django 2.2 or earlier. We&#39;ve
:ref:`dropped some features&lt;removed-features-3.0&gt;` that have reached the end of
their deprecation cycle, and we&#39;ve :ref:`begun the deprecation process for
some features &lt;deprecated-features-3.0&gt;`.

See the :doc:`/howto/upgrade-version` guide if you&#39;re updating an existing
project.

Python compatibility
====================

Django 3.0 supports Python 3.6, 3.7, and 3.8. We **highly recommend** and only
officially support the latest release of each series.

The Django 2.2.x series is the last to support Python 3.5.

Third-party library support for older version of Django
=======================================================

Following the release of Django 3.0, we suggest that third-party app authors
drop support for all versions of Django prior to 2.2. At that time, you should
be able to run your package&#39;s tests using ``python -Wd`` so that deprecation
warnings appear. After making the deprecation warning fixes, your app should be
compatible with Django 3.0.

.. _whats-new-3.0:

What&#39;s new in Django 3.0
========================

MariaDB support
---------------

Django now officially supports `MariaDB &lt;https://mariadb.org/&gt;`_ 10.1 and
higher. See :ref:`MariaDB notes &lt;mariadb-notes&gt;` for more details.

ASGI support
------------

Django 3.0 begins our journey to making Django fully async-capable by providing
support for running as an `ASGI &lt;https://asgi.readthedocs.io/&gt;`_ application.

This is in addition to our existing WSGI support. Django intends to support
both for the foreseeable future. Async features will only be available to
applications that run under ASGI, however.

At this stage async support only applies to the outer ASGI application.
Internally everything remains synchronous. Asynchronous middleware, views, etc.
are not yet supported. You can, however, use ASGI middleware around Django&#39;s
application, allowing you to combine Django with other ASGI frameworks.

There is no need to switch your applications over unless you want to start
experimenting with asynchronous code, but we have
:doc:`documentation on deploying with ASGI &lt;/howto/deployment/asgi/index&gt;` if
you want to learn more.

Note that as a side-effect of this change, Django is now aware of asynchronous
event loops and will block you calling code marked as &quot;async unsafe&quot; - such as
ORM operations - from an asynchronous context. If you were using Django from
async code before, this may trigger if you were doing it incorrectly. If you
see a ``SynchronousOnlyOperation`` error, then closely examine your code and
move any database operations to be in a synchronous child thread.

Exclusion constraints on PostgreSQL
-----------------------------------

The new :class:`~django.contrib.postgres.constraints.ExclusionConstraint` class
enable adding exclusion constraints on PostgreSQL. Constraints are added to
models using the
:attr:`Meta.constraints &lt;django.db.models.Options.constraints&gt;` option.

Filter expressions
------------------

Expressions that output :class:`~django.db.models.BooleanField` may now be
used directly in ``QuerySet`` filters, without having to first annotate and
then filter against the annotation.

Enumerations for model field choices
------------------------------------

Custom enumeration types ``TextChoices``, ``IntegerChoices``, and ``Choices``
are now available as a way to define :attr:`.Field.choices`. ``TextChoices``
and ``IntegerChoices`` types are provided for text and integer fields. The
``Choices`` class allows defining a compatible enumeration for other concrete
data types. These custom enumeration types support human-readable labels that
can be translated and accessed via a property on the enumeration or its
members. See :ref:`Enumeration types &lt;field-choices-enum-types&gt;` for more
details and examples.

Minor features
--------------

:mod:`django.contrib.admin`
~~~~~~~~~~~~~~~~~~~~~~~~~~~

* Added support for the ``admin_order_field`` attribute on properties in
  :attr:`.ModelAdmin.list_display`.

* The new :meth:`ModelAdmin.get_inlines()
  &lt;django.contrib.admin.ModelAdmin.get_inlines&gt;` method allows specifying the
  inlines based on the request or model instance.

* Select2 library is upgraded from version 4.0.3 to 4.0.7.

* jQuery is upgraded from version 3.3.1 to 3.4.1.

:mod:`django.contrib.auth`
~~~~~~~~~~~~~~~~~~~~~~~~~~

* The new ``reset_url_token`` attribute in
  :class:`~django.contrib.auth.views.PasswordResetConfirmView` allows
  specifying a token parameter displayed as a component of password reset
  URLs.

* Added :class:`~django.contrib.auth.backends.BaseBackend` class to ease
  customization of authentication backends.

* Added :meth:`~django.contrib.auth.models.User.get_user_permissions()` method
  to mirror the existing
  :meth:`~django.contrib.auth.models.User.get_group_permissions()` method.

* Added HTML ``autocomplete`` attribute to widgets of username, email, and
  password fields in :mod:`django.contrib.auth.forms` for better interaction
  with browser password managers.

* :djadmin:`createsuperuser` now falls back to environment variables for
  password and required fields, when a corresponding command line argument
  isn&#39;t provided in non-interactive mode.

* :attr:`~django.contrib.auth.models.CustomUser.REQUIRED_FIELDS` now supports
  :class:`~django.db.models.ManyToManyField`\s.

* The new :meth:`.UserManager.with_perm` method returns users that have the
  specified permission.

* The default iteration count for the PBKDF2 password hasher is increased from
  150,000 to 180,000.

:mod:`django.contrib.gis`
~~~~~~~~~~~~~~~~~~~~~~~~~

* Allowed MySQL spatial lookup functions to operate on real geometries.
  Previous support was limited to bounding boxes.

* Added the :class:`~django.contrib.gis.db.models.functions.GeometryDistance`
  function, supported on PostGIS.

* Added support for the ``furlong`` unit in
  :class:`~django.contrib.gis.measure.Distance`.

* The :setting:`GEOIP_PATH` setting now supports :class:`pathlib.Path`.

* The :class:`~django.contrib.gis.geoip2.GeoIP2` class now accepts
  :class:`pathlib.Path` ``path``.

:mod:`django.contrib.postgres`
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

* The new :class:`~django.contrib.postgres.fields.RangeOperators` helps to
  avoid typos in SQL operators that can be used together with
  :class:`~django.contrib.postgres.fields.RangeField`.

* The new :class:`~django.contrib.postgres.fields.RangeBoundary` expression
  represents the range boundaries.

* The new :class:`~django.contrib.postgres.operations.AddIndexConcurrently`
  and :class:`~django.contrib.postgres.operations.RemoveIndexConcurrently`
  classes allow creating and dropping indexes ``CONCURRENTLY`` on PostgreSQL.

:mod:`django.contrib.sessions`
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

* The new
  :meth:`~django.contrib.sessions.backends.base.SessionBase.get_session_cookie_age()`
  method allows dynamically specifying the session cookie age.

:mod:`django.contrib.syndication`
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

* Added the ``language`` class attribute to the
  :class:`django.contrib.syndication.views.Feed` to customize a feed language.
  The default value is :func:`~django.utils.translation.get_language()` instead
  of :setting:`LANGUAGE_CODE`.

Cache
~~~~~

* :func:`~django.utils.cache.add_never_cache_headers` and
  :func:`~django.views.decorators.cache.never_cache` now add the ``private``
  directive to ``Cache-Control`` headers.

File Storage
~~~~~~~~~~~~

* The new :meth:`.Storage.get_alternative_name` method allows customizing the
  algorithm for generating filenames if a file with the uploaded name already
  exists.

Forms
~~~~~

* Formsets may control the widget used when ordering forms via
  :attr:`~django.forms.formsets.BaseFormSet.can_order` by setting the
  :attr:`~django.forms.formsets.BaseFormSet.ordering_widget` attribute or
  overriding :attr:`~django.forms.formsets.BaseFormSet.get_ordering_widget()`.

Internationalization
~~~~~~~~~~~~~~~~~~~~

* Added the :setting:`LANGUAGE_COOKIE_HTTPONLY`,
  :setting:`LANGUAGE_COOKIE_SAMESITE`, and :setting:`LANGUAGE_COOKIE_SECURE`
  settings to set the ``HttpOnly``, ``SameSite``, and ``Secure`` flags on
  language cookies. The default values of these settings preserve the previous
  behavior.

* Added support and translations for the Uzbek language.

Logging
~~~~~~~

* The new ``reporter_class`` parameter of
  :class:`~django.utils.log.AdminEmailHandler` allows providing an
  ``django.views.debug.ExceptionReporter`` subclass to customize the traceback
  text sent to site :setting:`ADMINS` when :setting:`DEBUG` is ``False``.

Management Commands
~~~~~~~~~~~~~~~~~~~

* The new :option:`compilemessages --ignore` option allows ignoring specific
  directories when searching for ``.po`` files to compile.

* :option:`showmigrations --list` now shows the applied datetimes when
  ``--verbosity`` is 2 and above.

* On PostgreSQL, :djadmin:`dbshell` now supports client-side TLS certificates.

* :djadmin:`inspectdb` now introspects :class:`~django.db.models.OneToOneField`
  when a foreign key has a unique or primary key constraint.

* The new :option:`--skip-checks` option skips running system checks prior to
  running the command.

* The :option:`startapp --template` and :option:`startproject --template`
  options now support templates stored in XZ archives (``.tar.xz``, ``.txz``)
  and LZMA archives (``.tar.lzma``, ``.tlz``).

Models
~~~~~~

* Added hash database functions :class:`~django.db.models.functions.MD5`,
  :class:`~django.db.models.functions.SHA1`,
  :class:`~django.db.models.functions.SHA224`,
  :class:`~django.db.models.functions.SHA256`,
  :class:`~django.db.models.functions.SHA384`, and
  :class:`~django.db.models.functions.SHA512`.

* Added the :class:`~django.db.models.functions.Sign` database function.

* The new ``is_dst``  parameter of the
  :class:`~django.db.models.functions.Trunc` database functions determines the
  treatment of nonexistent and ambiguous datetimes.

* ``connection.queries`` now shows ``COPY … TO`` statements on PostgreSQL.

* :class:`~django.db.models.FilePathField` now accepts a callable for ``path``.

* Allowed symmetrical intermediate table for self-referential
  :class:`~django.db.models.ManyToManyField`.

* The ``name`` attributes of :class:`~django.db.models.CheckConstraint`,
  :class:`~django.db.models.UniqueConstraint`, and
  :class:`~django.db.models.Index` now support app label and class
  interpolation using the ``&#39;%(app_label)s&#39;`` and ``&#39;%(class)s&#39;`` placeholders.

* The new :attr:`.Field.descriptor_class` attribute allows model fields to
  customize the get and set behavior by overriding their
  :py:ref:`descriptors &lt;descriptors&gt;`.

* :class:`~django.db.models.Avg` and :class:`~django.db.models.Sum` now support
  the ``distinct`` argument.

* Added :class:`~django.db.models.SmallAutoField` which acts much like an
  :class:`~django.db.models.AutoField` except that it only allows values under
  a certain (database-dependent) limit. Values from ``1`` to ``32767`` are safe
  in all databases supported by Django.

* :class:`~django.db.models.AutoField`,
  :class:`~django.db.models.BigAutoField`, and
  :class:`~django.db.models.SmallAutoField` now inherit from
  ``IntegerField``, ``BigIntegerField`` and ``SmallIntegerField`` respectively.
  System checks and validators are now also properly inherited.

* :attr:`.FileField.upload_to` now supports :class:`pathlib.Path`.

* :class:`~django.db.models.CheckConstraint` is now supported on MySQL 8.0.16+.

* The new ``allows_group_by_selected_pks_on_model()`` method of
  ``django.db.backends.base.BaseDatabaseFeatures`` allows optimization of
  ``GROUP BY`` clauses to require only the selected models&#39; primary keys. By
  default, it&#39;s supported only for managed models on PostgreSQL.

  To enable the ``GROUP BY`` primary key-only optimization for unmanaged
  models, you have to subclass the PostgreSQL database engine, overriding the
  features class ``allows_group_by_selected_pks_on_model()`` method as you
  require. See :ref:`Subclassing the built-in database backends
  &lt;subclassing-database-backends&gt;` for an example.

Requests and Responses
~~~~~~~~~~~~~~~~~~~~~~

* Allowed :class:`~django.http.HttpResponse` to be initialized with
  :class:`memoryview` content.

* For use in, for example, Django templates, :attr:`.HttpRequest.headers` now
  allows lookups using underscores (e.g. ``user_agent``) in place of hyphens.

.. _whats-new-security-3.0:

Security
~~~~~~~~

* :setting:`X_FRAME_OPTIONS` now defaults to ``&#39;DENY&#39;``. In older versions, the
  :setting:`X_FRAME_OPTIONS` setting defaults to ``&#39;SAMEORIGIN&#39;``. If your site
  uses frames of itself, you will need to explicitly set ``X_FRAME_OPTIONS =
  &#39;SAMEORIGIN&#39;`` for them to continue working.

* :setting:`SECURE_CONTENT_TYPE_NOSNIFF` now defaults to ``True``. With this
  enabled, :class:`~django.middleware.security.SecurityMiddleware` sets the
  :ref:`x-content-type-options` header on all responses that do not already
  have it.

* :class:`~django.middleware.security.SecurityMiddleware` can now send the
  :ref:`Referrer-Policy &lt;referrer-policy&gt;` header.

Tests
~~~~~

* The new test :class:`~django.test.Client` argument
  ``raise_request_exception`` allows controlling whether or not exceptions
  raised during the request should also be raised in the test. The value
  defaults to ``True`` for backwards compatibility. If it is ``False`` and an
  exception occurs, the test client will return a 500 response with the
  attribute :attr:`~django.test.Response.exc_info`, a tuple providing
  information of the exception that occurred.

* Tests and test cases to run can be selected by test name pattern using the
  new :option:`test -k` option.

* HTML comparison, as used by
  :meth:`~django.test.SimpleTestCase.assertHTMLEqual`, now treats text, character
  references, and entity references that refer to the same character as
  equivalent.

* Django test runner now supports headless mode for selenium tests on supported
  browsers. Add the ``--headless`` option to enable this mode.

* Django test runner now supports ``--start-at`` and ``--start-after`` options
  to run tests starting from a specific top-level module.

* Django test runner now supports a ``--pdb`` option to spawn a debugger at
  each error or failure.

.. _backwards-incompatible-3.0:

Backwards incompatible changes in 3.0
=====================================

``Model.save()`` when providing a default for the primary key
-------------------------------------------------------------

:meth:`.Model.save` no longer attempts to find a row when saving a new
``Model`` instance and a default value for the primary key is provided, and
always performs a single ``INSERT`` query. In older Django versions,
``Model.save()`` performed either an ``INSERT`` or an ``UPDATE`` based on
whether or not the row exists.

This makes calling ``Model.save()`` while providing a default primary key value
equivalent to passing :ref:`force_insert=True &lt;ref-models-force-insert&gt;` to
model&#39;s ``save()``. Attempts to use a new ``Model`` instance to update an
existing row will result in an ``IntegrityError``.

In order to update an existing model for a specific primary key value, use the
:meth:`~django.db.models.query.QuerySet.update_or_create` method or
``QuerySet.filter(pk=…).update(…)`` instead. For example::

    &gt;&gt;&gt; MyModel.objects.update_or_create(pk=existing_pk, defaults={&#39;name&#39;: &#39;new name&#39;})
    &gt;&gt;&gt; MyModel.objects.filter(pk=existing_pk).update(name=&#39;new name&#39;)

Database backend API
--------------------

This section describes changes that may be needed in third-party database
backends.

* The second argument of ``DatabaseIntrospection.get_geometry_type()`` is now
  the row description instead of the column name.

* ``DatabaseIntrospection.get_field_type()`` may no longer return tuples.

* If the database can create foreign keys in the same SQL statement that adds a
  field, add ``SchemaEditor.sql_create_column_inline_fk`` with the appropriate
  SQL; otherwise, set ``DatabaseFeatures.can_create_inline_fk = False``.

* ``DatabaseFeatures.can_return_id_from_insert`` and
  ``can_return_ids_from_bulk_insert`` are renamed to
  ``can_return_columns_from_insert`` and ``can_return_rows_from_bulk_insert``.

* Database functions now handle :class:`datetime.timezone` formats when created
  using :class:`datetime.timedelta` instances (e.g.
  ``timezone(timedelta(hours=5))``, which would output ``&#39;UTC+05:00&#39;``).
  Third-party backends should handle this format when preparing
  :class:`~django.db.models.DateTimeField` in ``datetime_cast_date_sql()``,
  ``datetime_extract_sql()``, etc.

* Entries for ``AutoField``, ``BigAutoField``, and ``SmallAutoField`` are added
  to  ``DatabaseOperations.integer_field_ranges`` to support the integer range
  validators on these field types. Third-party backends may need to customize
  the default entries.

* ``DatabaseOperations.fetch_returned_insert_id()`` is replaced by
  ``fetch_returned_insert_columns()`` which returns a list of values returned
  by the ``INSERT … RETURNING`` statement, instead of a single value.

* ``DatabaseOperations.return_insert_id()`` is replaced by
  ``return_insert_columns()`` that accepts a ``fields``
  argument, which is an iterable of fields to be returned after insert. Usually
  this is only the auto-generated primary key.

:mod:`django.contrib.admin`
---------------------------

* Admin&#39;s model history change messages now prefers more readable field labels
  instead of field names.

:mod:`django.contrib.gis`
-------------------------

* Support for PostGIS 2.1 is removed.

* Support for SpatiaLite 4.1 and 4.2 is removed.

* Support for GDAL 1.11 and GEOS 3.4 is removed.

Dropped support for PostgreSQL 9.4
----------------------------------

Upstream support for PostgreSQL 9.4 ends in December 2019. Django 3.0 supports
PostgreSQL 9.5 and higher.

Dropped support for Oracle 12.1
-------------------------------

Upstream support for Oracle 12.1 ends in July 2021. Django 2.2 will be
supported until April 2022. Django 3.0 officially supports Oracle 12.2 and 18c.

Removed private Python 2 compatibility APIs
-------------------------------------------

While Python 2 support was removed in Django 2.0, some private APIs weren&#39;t
removed from Django so that third party apps could continue using them until
the Python 2 end-of-life.

Since we expect apps to drop Python 2 compatibility when adding support for
Django 3.0, we&#39;re removing these APIs at this time.

* ``django.test.utils.str_prefix()`` - Strings don&#39;t have &#39;u&#39; prefixes in
  Python 3.

* ``django.test.utils.patch_logger()`` - Use
  :meth:`unittest.TestCase.assertLogs` instead.

* ``django.utils.lru_cache.lru_cache()`` - Alias of
  :func:`functools.lru_cache`.

* ``django.utils.decorators.available_attrs()`` - This function returns
  ``functools.WRAPPER_ASSIGNMENTS``.

* ``django.utils.decorators.ContextDecorator`` - Alias of
  :class:`contextlib.ContextDecorator`.

* ``django.utils._os.abspathu()`` - Alias of :func:`os.path.abspath`.

* ``django.utils._os.upath()`` and ``npath()`` - These functions do nothing on
  Python 3.

* ``django.utils.six`` - Remove usage of this vendored library or switch to
  `six &lt;https://pypi.org/project/six/&gt;`_.

* ``django.utils.encoding.python_2_unicode_compatible()`` - Alias of
  ``six.python_2_unicode_compatible()``.

* ``django.utils.functional.curry()`` - Use :func:`functools.partial` or
  :class:`functools.partialmethod`. See :commit:`5b1c389603a353625ae1603`.

* ``django.utils.safestring.SafeBytes`` - Unused since Django 2.0.

New default value for the ``FILE_UPLOAD_PERMISSIONS`` setting
-------------------------------------------------------------

In older versions, the :setting:`FILE_UPLOAD_PERMISSIONS` setting defaults to
``None``. With the default :setting:`FILE_UPLOAD_HANDLERS`, this results in
uploaded files having different permissions depending on their size and which
upload handler is used.

``FILE_UPLOAD_PERMISSIONS`` now defaults to ``0o644`` to avoid this
inconsistency.

New default values for security settings
----------------------------------------

To make Django projects more secure by default, some security settings now have
more secure default values:

* :setting:`X_FRAME_OPTIONS` now defaults to ``&#39;DENY&#39;``.

* :setting:`S